### PR TITLE
Change spelling of CreateWebHostBuider to CreateWebHostBuilder

### DIFF
--- a/src/IdentityServer4.Contrib.AspNetCore.Testing/Builder/IdentityServerTestWebHostBuilder.cs
+++ b/src/IdentityServer4.Contrib.AspNetCore.Testing/Builder/IdentityServerTestWebHostBuilder.cs
@@ -59,7 +59,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Builder
             return this;
         }
 
-        public IWebHostBuilder CreateWebHostBuider()
+        public IWebHostBuilder CreateWebHostBuilder()
         {
             if (this.internalHostBuilder != null) return this.internalHostBuilder;
 

--- a/test/IdentityServer4.Contrib.AspNetCore.Testing.Tests/IdentityServerWebHostBuilderTests.cs
+++ b/test/IdentityServer4.Contrib.AspNetCore.Testing.Tests/IdentityServerWebHostBuilderTests.cs
@@ -42,7 +42,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
                     context.HostingEnvironment.WebRootPath = AppContext.BaseDirectory;
                     builder.AddJsonFile(Path.Combine(AppContext.BaseDirectory, "testappsettings.json"), false);
                 })
-                .CreateWebHostBuider()
+                .CreateWebHostBuilder()
                 .Build();
 
             var configuration = webHost.Services.GetRequiredService<IConfiguration>();
@@ -60,7 +60,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
 
             var webHost = new IdentityServerTestWebHostBuilder()
                 .UseLoggingBuilder((context, builder) => builder.AddSerilog())
-                .CreateWebHostBuider()
+                .CreateWebHostBuilder()
                 .UseContentRoot(AppContext.BaseDirectory)
                 .Build();
 
@@ -79,7 +79,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
         {
             var webHost = new IdentityServerTestWebHostBuilder()
                 .UseProfileService(new SimpleProfileService())
-                .CreateWebHostBuider()
+                .CreateWebHostBuilder()
                 .Build();
 
             webHost.Services.GetRequiredService<IProfileService>();
@@ -97,7 +97,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
         {
             var webHost = new IdentityServerTestWebHostBuilder()
                 .UseProfileService(typeof(SimpleProfileService))
-                .CreateWebHostBuider()
+                .CreateWebHostBuilder()
                 .Build();
 
             webHost.Services.GetRequiredService<IProfileService>();
@@ -108,7 +108,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
         {
             var webHost = new IdentityServerTestWebHostBuilder()
                 .UseResourceOwnerPasswordValidator(new SimpleResourceOwnerPasswordValidator())
-                .CreateWebHostBuider()
+                .CreateWebHostBuilder()
                 .Build();
 
             webHost.Services.GetRequiredService<IResourceOwnerPasswordValidator>();
@@ -126,7 +126,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
         {
             var webHost = new IdentityServerTestWebHostBuilder()
                 .UseResourceOwnerPasswordValidator(typeof(SimpleResourceOwnerPasswordValidator))
-                .CreateWebHostBuider()
+                .CreateWebHostBuilder()
                 .Build();
 
             webHost.Services.GetRequiredService<IResourceOwnerPasswordValidator>();
@@ -140,7 +140,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
             var webHost = new IdentityServerTestWebHostBuilder()
                 .UseLoggingBuilder((context, builder) => builder.AddSerilog())
                 .UseResourceOwnerPasswordValidator(typeof(ResourceOwnerValidatorWithDependencies))
-                .CreateWebHostBuider()
+                .CreateWebHostBuilder()
                 .Build();
 
             webHost.Services.GetRequiredService<IResourceOwnerPasswordValidator>();

--- a/test/IdentityServer4.Contrib.AspNetCore.Testing.Tests/IdentityServerWebHostProxyTests.cs
+++ b/test/IdentityServer4.Contrib.AspNetCore.Testing.Tests/IdentityServerWebHostProxyTests.cs
@@ -46,7 +46,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
                 .AddClients(client)
                 .AddApiResources(new ApiResource("api1", "api1name"))
                 .AddApiScopes(new ApiScope("api1"))
-                .CreateWebHostBuider();
+                .CreateWebHostBuilder();
 
             var identityServerProxy = new IdentityServerWebHostProxy(webHostBuilder);
 
@@ -90,7 +90,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
                 .AddClients(client)
                 .AddApiResources(new ApiResource("api1", "api1name"))
                 .AddApiScopes(new ApiScope("api1"))
-                .CreateWebHostBuider();
+                .CreateWebHostBuilder();
 
             var identityServerProxy = new IdentityServerWebHostProxy(webHostBuilder);
 
@@ -125,7 +125,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
                 .AddClients(client)
                 .AddApiResources(new ApiResource("api1", "api1name"))
                 .AddApiScopes(new ApiScope("api1"))
-                .CreateWebHostBuider();
+                .CreateWebHostBuilder();
 
             var identityServerProxy = new IdentityServerWebHostProxy(webHostBuilder);
 
@@ -156,7 +156,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
                 })
                 .AddApiResources(new ApiResource())
                 .AddApiScopes(new ApiScope())
-                .CreateWebHostBuider();
+                .CreateWebHostBuilder();
 
             var identityServerClient = new IdentityServerWebHostProxy(webHostBuilder);
             var discoveryResponse = await identityServerClient.GetDiscoverResponseAsync();
@@ -189,7 +189,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
                 .AddApiResources(new ApiResource("api1", "api1name"))
                 .UseResourceOwnerPasswordValidator(new SimpleResourceOwnerPasswordValidator())
                 .AddApiScopes(new ApiScope("api1"))
-                .CreateWebHostBuider();
+                .CreateWebHostBuilder();
 
             var identityServerProxy = new IdentityServerWebHostProxy(webHostBuilder);
 
@@ -240,7 +240,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
                 .AddApiResources(new ApiResource("api1", "api1name"))
                 .AddApiScopes(new ApiScope("api1"))
                 .UseResourceOwnerPasswordValidator(new SimpleResourceOwnerPasswordValidator())
-                .CreateWebHostBuider();
+                .CreateWebHostBuilder();
 
             var identityServerProxy = new IdentityServerWebHostProxy(webHostBuilder);
 
@@ -277,7 +277,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
         {
             var host = new IdentityServerTestWebHostBuilder()
                 .UseWebHostBuilder(Program.CreateWebHostBuilder(new string[] { }))
-                .CreateWebHostBuider();
+                .CreateWebHostBuilder();
 
             var proxy = new IdentityServerWebHostProxy(host);
 
@@ -314,7 +314,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
                 .AddApiResources(new ApiResource("api1", "api1name"))
                 .AddApiScopes(new ApiScope())
                 .UseResourceOwnerPasswordValidator(new SimpleResourceOwnerPasswordValidator())
-                .CreateWebHostBuider();
+                .CreateWebHostBuilder();
 
             var identityServerClient = new IdentityServerWebHostProxy(webHostBuilder);
 
@@ -356,7 +356,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
                     .AddDefaultEndpoints()
                     .AddDeveloperSigningCredential()
                 )
-                .CreateWebHostBuider();
+                .CreateWebHostBuilder();
 
             var identityServerProxy = new IdentityServerWebHostProxy(webHostBuilder);
 
@@ -398,7 +398,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
                 .AddApiScopes(new ApiScope("api1"))
                 .UseResourceOwnerPasswordValidator(typeof(SimpleResourceOwnerPasswordValidator))
                 .UseIdentityServerOptionsBuilder(options => options.Endpoints.EnableTokenEndpoint = false)
-                .CreateWebHostBuider();
+                .CreateWebHostBuilder();
 
             var identityServerProxy = new IdentityServerWebHostProxy(webHostBuilder);
 
@@ -434,7 +434,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
                 .AddClients(client)
                 .AddApiResources(new ApiResource("api1", "api1name"))
                 .AddApiScopes(new ApiScope("api1"))
-                .CreateWebHostBuider();
+                .CreateWebHostBuilder();
 
             var identityServerProxy = new IdentityServerWebHostProxy(webHostBuilder);
 
@@ -474,7 +474,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
                 .AddApiResources(new ApiResource("api1", "api1name"))
                 .AddApiScopes(new ApiScope("api1"))
                 .UseResourceOwnerPasswordValidator(typeof(SimpleResourceOwnerPasswordValidator))
-                .CreateWebHostBuider();
+                .CreateWebHostBuilder();
 
             var identityServerProxy = new IdentityServerWebHostProxy(webHostBuilder);
 
@@ -514,7 +514,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
                 .AddApiResources(new ApiResource("api1", "api1name"))
                 .AddApiScopes(new ApiScope("api1"))
                 .UseResourceOwnerPasswordValidator(new SimpleResourceOwnerPasswordValidator())
-                .CreateWebHostBuider();
+                .CreateWebHostBuilder();
 
             var identityServerProxy = new IdentityServerWebHostProxy(webHostBuilder);
 
@@ -563,7 +563,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
                 .AddIdentityResources(new IdentityResources.OpenId(), new IdentityResources.Profile())
                 .UseServices((context, collection) =>
                     collection.AddScoped<IExtensionGrantValidator, ExtensionsGrantValidator>())
-                .CreateWebHostBuider();
+                .CreateWebHostBuilder();
 
             var identityServerProxy = new IdentityServerWebHostProxy(webHostBuilder);
 
@@ -614,7 +614,7 @@ namespace IdentityServer4.Contrib.AspNetCore.Testing.Tests
                 .AddIdentityResources(new IdentityResources.OpenId(), new IdentityResources.Profile())
                 .UseResourceOwnerPasswordValidator(new SimpleResourceOwnerPasswordValidator())
                 .UseProfileService(new SimpleProfileService())
-                .CreateWebHostBuider();
+                .CreateWebHostBuilder();
 
             var identityServerProxy = new IdentityServerWebHostProxy(webHostBuilder);
 


### PR DESCRIPTION
After reading the [documentation](https://github.com/alsami/IdentityServer4.Contrib.AspNetCore.Testing/blob/master/docs/IdentityServerTestWebHostBuilder.md) on the usage of the library, I noticed that there is some misaligned between the code and the documentation.

![image](https://user-images.githubusercontent.com/1062417/144597619-80ddcf69-22b0-466e-a916-b42287e6604d.png)


I appreciate that this is a breaking change, i'm more than happy to close this PR and open one to align the documentation.